### PR TITLE
[devlock] Do not check devicelock in ACTDEAD. JB#15041

### DIFF
--- a/src/usb_moded.c
+++ b/src/usb_moded.c
@@ -285,12 +285,16 @@ void set_usb_mode(const char *mode)
   int export = 1;
 
   /* check if we are allowed to export system contents 0 is unlocked */
-  export = usb_moded_get_export_permission();
-
-  if(export)
+  /* In ACTDEAD export is always ok */
+  if(is_in_user_state())
   {
-	log_debug("Secondary device lock check failed. Not setting mode!\n");
-	goto end;
+	export = usb_moded_get_export_permission();
+
+	if(export)
+	{
+		log_debug("Secondary device lock check failed. Not setting mode!\n");
+		goto end;
+  	}
   }
 #endif /* MEEGOLOCK */
 


### PR DESCRIPTION
Because of this extra devicelock check, device didn't get correct usb cable state in ACTDEAD mode. That caused device to shutdown and then boot again -> no cable information -> shutdown -> reboot loop

Now this extra check is done only in USER state.
