### PR TITLE
[udev] Remove udev defines as it is the only and default one

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,14 +70,6 @@ AC_ARG_ENABLE([app_sync_dbus], AS_HELP_STRING([--enable-app-sync-dbus], [Enable 
    esac],[app_sync_dbus=false])
 AM_CONDITIONAL([APP_SYNC_DBUS], [test x$app_sync_dbus = xtrue])
 
-AC_ARG_ENABLE([udev], AS_HELP_STRING([--enable-udev], [Enable udev interface @<:@default=true@:>@]),
-  [case "${enableval}" in
-   yes) udev=true ; CFLAGS="-DUDEV -ludev $CFLAGS" ;;
-   no)  udev=false ;;
-   *) AC_MSG_ERROR([bad value ${enableval} for --enable-udev]) ;;
-   esac],[udev=true CFLAGS="-DUDEV -ludev $CFLAGS" ])
-AM_CONDITIONAL([UDEV], [test x$udev = xtrue])
-
 AC_ARG_ENABLE([upstart], AS_HELP_STRING([--enable-upstart], [Enable upstart interface for appsync @<:@default=false@:>@]),
   [case "${enableval}" in
    yes) upstart=true ; CFLAGS="-DUPSTART $CFLAGS" ;;
@@ -116,6 +108,7 @@ PKG_CHECK_MODULES([USB_MODED], [
  dbus-glib-1 >= 0.78
  gobject-2.0 >= 2.16.6
  gio-2.0
+ libudev
  libkmod
 ])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,15 +32,11 @@ usb_moded_SOURCES = \
 	usb_moded-mac.h \
 	usb_moded-dyn-config.c \
 	usb_moded-dyn-config.h \
+	usb_moded-udev.c \
+	usb_moded-trigger.c \
 	usb_moded-modules.c \
 	usb_moded-android.h \
 	usb_moded-android.c
-
-if UDEV
-usb_moded_SOURCES += \
-	usb_moded-udev.c \
-	usb_moded-trigger.c
-endif
 
 if MEEGOLOCK
 usb_moded_SOURCES += \

--- a/src/usb_moded-config.c
+++ b/src/usb_moded-config.c
@@ -85,7 +85,6 @@ const char * find_alt_mount(void)
   return(get_conf_string(ALT_MOUNT_ENTRY, ALT_MOUNT_KEY));
 }
 
-#ifdef UDEV
 const char * find_udev_path(void)
 {
   return(get_conf_string(UDEV_PATH_ENTRY, UDEV_PATH_KEY));
@@ -95,7 +94,6 @@ const char * find_udev_subsystem(void)
 {
   return(get_conf_string(UDEV_PATH_ENTRY, UDEV_SUBSYSTEM_KEY));
 }
-#endif /* UDEV */
 
 #ifdef NOKIA
 const char * find_cdrom_path(void)
@@ -109,7 +107,6 @@ int find_cdrom_timeout(void)
 }
 #endif /* NOKIA */
 
-#ifdef UDEV
 const char * check_trigger(void)
 {
   return(get_conf_string(TRIGGER_ENTRY, TRIGGER_PATH_KEY));
@@ -134,7 +131,6 @@ const char * get_trigger_value(void)
 {
   return(get_conf_string(TRIGGER_ENTRY, TRIGGER_PROPERTY_VALUE_KEY));
 }
-#endif /* UDEV */
 
 const char * get_network_ip(void)
 {
@@ -466,9 +462,7 @@ int conf_file_merge(void)
   GString *keyfile_string = NULL;
   GKeyFile *settingsfile;
   int ret = 0, test = 0, conffile_created = 0;
-#ifdef UDEV
   const gchar *udev = 0;
-#endif /* UDEV */
 
   confdir = g_dir_open(CONFIG_FILE_DIR, 0, NULL);
   if(!confdir)
@@ -516,10 +510,8 @@ int conf_file_merge(void)
 	{
 		/* store mode info to add it later as we want to keep it */
 		mode = get_mode_setting();
-#ifdef UDEV
 		/* store udev path (especially important for the upgrade path */
 		udev = find_udev_path();
-#endif /* UDEV */
 		ip = get_conf_string(NETWORK_ENTRY, NETWORK_IP_KEY);
 		gateway = get_conf_string(NETWORK_ENTRY, NETWORK_GATEWAY_KEY);
 		continue;
@@ -551,7 +543,6 @@ next:
 	{
 		set_mode_setting(mode);
 	}
-#ifdef UDEV
 	if(udev)
 	{
 		set_config_setting(UDEV_PATH_ENTRY, UDEV_PATH_KEY, udev);
@@ -563,18 +554,14 @@ next:
 		set_network_setting(NETWORK_IP_KEY, ip);
 	if(gateway)
 		set_network_setting(NETWORK_GATEWAY_KEY, gateway);
-		
-#endif /* UDEV */
   }
   else
 	ret = 1;
 cleanup:
   if(mode)
   	free((void *)mode);
-#ifdef UDEV
   if(udev)
 	free((void *)udev);
-#endif /* UDEV */
   if(ip)
 	free((void *)ip);
   if(gateway)

--- a/src/usb_moded-config.h
+++ b/src/usb_moded-config.h
@@ -60,23 +60,19 @@ const char * find_mounts(void);
 int find_sync(void);
 const char * find_alt_mount(void);
 
-#ifdef UDEV
 const char * find_udev_path(void);
 const char * find_udev_subsystem(void);
-#endif
 
 #ifdef NOKIA
 const char * find_cdrom_path(void);
 int find_cdrom_timeout(void);
 #endif
 
-#ifdef UDEV
 const char * check_trigger(void);
 const char * get_trigger_subsystem(void);
 const char * get_trigger_mode(void);
 const char * get_trigger_property(void);
 const char * get_trigger_value(void);
-#endif /* UDEV */
 
 const char * get_network_ip(void);
 const char * get_network_interface(void);

--- a/src/usb_moded.c
+++ b/src/usb_moded.c
@@ -553,10 +553,8 @@ static void usb_moded_init(void)
   modelist = read_mode_list(diag_mode);
 #endif /* APP_SYNC */
 
-#ifdef UDEV
   if(check_trigger())
 	trigger_init();
-#endif /* UDEV */
 
   /* Set-up mac address before kmod */
   if(access("/etc/modprobe.d/g_ether.conf", F_OK) != 0)


### PR DESCRIPTION
Since hal has been replaced and removed long ago, there is no reason
to keep udev separated. Makes code easier to read and eases Makefile
maintenance.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
