### PR TITLE
Use lstat to read information about the link

### DIFF
--- a/src/usb_moded-network.c
+++ b/src/usb_moded-network.c
@@ -387,7 +387,7 @@ static int write_udhcpd_conf(struct ipforward_data *ipforward, struct mode_list_
   log_debug("/etc/udhcpd.conf written.\n");
 
   /* check if it is a symlink, if not remove and link, create the link if missing */
-  test = stat("/etc/udhcpd.conf", &st);
+  test = lstat("/etc/udhcpd.conf", &st);
   /* if stat fails there is no file or link */
   if(test == -1)
 	goto link;


### PR DESCRIPTION
lstat() is identical to stat(), except that if path is a symbolic link, then the link itself is stat-ed, not the file that it refers to.