### PR TITLE
Fix memory leak in systemd_control_service()

### DIFF
--- a/src/usb_moded-systemd.c
+++ b/src/usb_moded-systemd.c
@@ -87,6 +87,7 @@ int systemd_control_service(const char *name, const char *method)
 	reply = dbus_connection_send_with_reply_and_block(bus, msg, -1, &error);
 	if(reply)
  	{
+		dbus_message_unref(reply);
 		ret = 0;
 	}
         dbus_message_unref(msg);	


### PR DESCRIPTION
```
==793== 2,856 (992 direct, 1,864 indirect) bytes in 8 blocks are definitely lost in loss record 370 of 372
==793==    at 0x4841B84: calloc (vg_replace_malloc.c:623)
==793==    by 0x48A68A7: dbus_message_new_empty_header (dbus-message.c:1141)
==793==    by 0x48AA14D: _dbus_message_loader_queue_messages (dbus-message.c:4248)
==793==    by 0x48AFD57: _dbus_transport_get_dispatch_status (dbus-transport.c:1101)
==793==    by 0x48AFDFD: _dbus_transport_queue_messages (dbus-transport.c:1128)
==793==    by 0x48B038F: do_reading (dbus-transport-socket.c:883)
==793==    by 0x48B0769: socket_do_iteration (dbus-transport-socket.c:1194)
==793==    by 0x48AFC9D: _dbus_transport_do_iteration (dbus-transport.c:976)
==793==    by 0x489FC7F: _dbus_connection_do_iteration_unlocked (dbus-connection.c:1234)
==793==    by 0x48A038F: _dbus_connection_block_pending_call (dbus-connection.c:2415)
==793==    by 0x48A076F: dbus_connection_send_with_reply_and_block (dbus-connection.c:3557)
==793==    by 0x111FE7: systemd_control_service (usb_moded-systemd.c:87)
==793==    by 0x111E8F: appsync_stop (usb_moded-appsync.c:438)
==793==    by 0x10F753: usb_moded_mode_cleanup (usb_moded-modesetting.c:533)
==793==    by 0x10BEAF: msg_handler (usb_moded-dbus.c:107)
==793==    by 0x48A1567: dbus_connection_dispatch (dbus-connection.c:4658)
==793==    by 0x48736F7: message_queue_dispatch (dbus-gmain.c:90)
==793==    by 0x4913B85: g_main_dispatch (gmain.c:3066)
==793==    by 0x4913B85: g_main_context_dispatch (gmain.c:3642)
==793==    by 0x4913E11: g_main_context_iterate.isra.5 (gmain.c:3713)
==793==    by 0x49141D3: g_main_loop_run (gmain.c:3907)
==793==    by 0x10AF33: main (usb_moded.c:991)
```