### PR TITLE
Remove BusName from the [Unit] section of usb-moded.service

### DIFF
--- a/systemd/usb-moded.service
+++ b/systemd/usb-moded.service
@@ -5,7 +5,6 @@ Wants=systemd-udev-settle.service
 Requires=dbus.socket
 After=local-fs.target dbus.socket systemd-udev-settle.service
 Conflicts=shutdown.target
-BusName=com.meego.usb_moded
 
 [Service]
 Type=notify


### PR DESCRIPTION
This value, if needed, is expected in the `[Service]` section according to systemd documentation:

http://www.freedesktop.org/software/systemd/man/systemd.service.html

And it's only needed if `Type=dbus`, otherwise it's ignored. If nothing else, this fixes this systemd warning:

```
systemd[1]: [/lib/systemd/system/usb-moded.service:8] Unknown lvalue 'BusName' in section 'Unit'
```