### PR TITLE
Include D-Bus spec in the devel package.

### DIFF
--- a/rpm/usb-moded.spec
+++ b/rpm/usb-moded.spec
@@ -302,6 +302,7 @@ make all doc %{?_smp_mflags}
 install -m 644 -D src/usb_moded-dbus.h %{buildroot}/%{_includedir}/%{name}/usb_moded-dbus.h
 install -m 644 -D src/usb_moded-modes.h %{buildroot}/%{_includedir}/%{name}/usb_moded-modes.h
 install -m 644 -D src/usb_moded-appsync-dbus.h %{buildroot}/%{_includedir}/%{name}/usb_moded-appsync-dbus.h
+install -m 644 -D src/com.meego.usb_moded.xml %{buildroot}/%{_includedir}/%{name}/com.meego.usb_moded.xml
 install -m 644 -D usb_moded.pc %{buildroot}/%{_libdir}/pkgconfig/usb_moded.pc
 install -d %{buildroot}/%{_docdir}/%{name}/html/
 install -m 644 docs/html/* %{buildroot}/%{_docdir}/%{name}/html/

--- a/src/com.meego.usb_moded.xml
+++ b/src/com.meego.usb_moded.xml
@@ -1,0 +1,44 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/com/meego/usb_moded">
+  <interface name="com.meego.usb_moded">
+    <method name="mode_request">
+      <arg name="mode" type="s" direction="out"/>
+    </method>
+    <method name="set_mode">
+      <arg name="mode" type="s" direction="in"/>
+      <arg name="mode" type="s" direction="out"/>
+    </method>
+    <method name="set_config">
+      <arg name="config" type="s" direction="in"/>
+      <arg name="config" type="s" direction="out"/>
+    </method>
+    <method name="net_config">
+      <arg name="key" type="s" direction="in"/>
+      <arg name="value" type="s" direction="in"/>
+      <arg name="key" type="s" direction="out"/>
+      <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="get_net_config">
+      <arg name="key" type="s" direction="in"/>
+      <arg name="key" type="s" direction="out"/>
+      <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="get_config">
+      <arg name="mode" type="s" direction="out"/>
+    </method>
+    <method name="get_modes">
+      <arg name="modes" type="s" direction="out"/>
+    </method>
+    <method name="rescue_off"/>
+    <signal name="sig_usb_state_ind">
+      <arg name="mode" type="s"/>
+    </signal>
+    <signal name="sig_usb_state_error_ind">
+      <arg name="error" type="s"/>
+    </signal>
+    <signal name="sig_usb_supported_modes_ind">
+      <arg name="modes" type="s"/>
+    </signal>
+  </interface>
+</node>


### PR DESCRIPTION
XML spec is needed for generating D-Bus stubs and it's better to keep it in usb-moded repository.