### PR TITLE
[usb-moded] Additional fix for broken usb drivers when setting mode

### DIFF
--- a/src/usb_moded.c
+++ b/src/usb_moded.c
@@ -131,6 +131,9 @@ void set_usb_connected(gboolean connected)
 	 */
 	if(current_mode.android_usb_broken)
 		set_android_charging_mode();
+	if (android_ignore_udev_events) {
+		android_ignore_next_udev_disconnect_event = TRUE;
+	}
   }		
 
 }


### PR DESCRIPTION
Fixes a continuous disconnect/connect loop when the first disconnect signal doesn't originate from user activity. This can happen when for example some process on a remote computer wants to reset the connection by disconnecting it.